### PR TITLE
Shape.point() functionality.

### DIFF
--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -2972,16 +2972,18 @@ class Shape(GraphicObject, Transformable):
         segment_start = 0
         for index, segment in enumerate(segments):
             segment_end = segment_start + self._lengths[index]
-            v0 = position[((segment_start < position) & (position < segment_end))]
+            position_subset = ((segment_start <= position) & (position < segment_end))
+            v0 = position[position_subset]
             if not len(v0):
-                continue
+                continue  # Nothing matched.
             d = segment_end - segment_start
-            if d == 0:
-                continue
-            segment_pos = (v0 - segment_start) / d
+            if d == 0:  # This segment is 0 length.
+                segment_pos = 0.0
+            else:
+                segment_pos = (v0 - segment_start) / d
             c = segment.point(segment_pos)
-            xy[((segment_start < position) & (position < segment_end)), 0] = c.x
-            xy[((segment_start < position) & (position < segment_end)), 1] = c.y
+            xy[position_subset, 0] = c.x
+            xy[position_subset, 1] = c.y
             segment_start = segment_end
         return Point(xy)
 

--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -1791,7 +1791,10 @@ class Point:
         return Point(self.x, self.y)
 
     def __str__(self):
-        x_str = ('%.12G' % (self.x))
+        try:
+            x_str = ('%.12G' % (self.x))
+        except TypeError:
+            return self.__repr__()
         if '.' in x_str:
             x_str = x_str.rstrip('0').rstrip('.')
         y_str = ('%.12G' % (self.y))
@@ -2725,6 +2728,8 @@ class Transformable(SVGElement):
     """Any element that is transformable and has a transform property."""
 
     def __init__(self, *args, **kwargs):
+        self._length = None
+        self._lengths = None
         self.transform = None
         self.apply = None
         SVGElement.__init__(self, *args, **kwargs)
@@ -2774,6 +2779,8 @@ class Transformable(SVGElement):
         The default method will be called by submethods but will only scale properties like stroke_width which should
         scale with the transform.
         """
+        self._lengths = None
+        self._length = None
         if SVG_ATTR_STROKE_WIDTH in self.values:
             width = Length(self.values[SVG_ATTR_STROKE_WIDTH]).value()
             t = self.transform
@@ -2924,6 +2931,101 @@ class Shape(GraphicObject, Transformable):
             self.transform *= other
         self.reify()
         return self
+
+    def _calc_lengths(self, error=ERROR, min_depth=MIN_DEPTH, segments=None):
+        """
+        Calculate the length values for the segments of the Shape.
+
+        :param error: error permitted for length calculations.
+        :param min_depth: minimum depth for the length calculation.
+        :param segments: optional segments to use.
+        :return:
+        """
+        if segments is None:
+            segments = self.segments(False)
+        if self._length is not None:
+            return
+        lengths = [each.length(error=error, min_depth=min_depth) for each in segments]
+        self._length = sum(lengths)
+        if self._length == 0:
+            self._lengths = lengths
+        else:
+            self._lengths = [each / self._length for each in lengths]
+
+    def _point_numpy(self, position, error=ERROR):
+        """
+        Find a points between 0 and 1 within the shape. Numpy acceleration allows points to be an array of floats.
+        """
+        segments = self.segments(False)
+        if len(segments) == 0:
+            return None
+        # Shortcuts
+        if self._length is None:
+            self._calc_lengths(error=error, segments=segments)
+        xy = np.empty((len(position), 2), dtype=float)
+        if self._length == 0:
+            i = int(round(position * (len(segments) - 1)))
+            point = segments[i].point(0.0)
+            xy[:] = point
+            return Point(xy)
+        # Find which segment the point we search for is located on:
+        segment_start = 0
+        for index, segment in enumerate(segments):
+            segment_end = segment_start + self._lengths[index]
+            v0 = position[((segment_start < position) & (position < segment_end))]
+            if not len(v0):
+                continue
+            d = segment_end - segment_start
+            if d == 0:
+                continue
+            segment_pos = (v0 - segment_start) / d
+            c = segment.point(segment_pos)
+            xy[((segment_start < position) & (position < segment_end)), 0] = c.x
+            xy[((segment_start < position) & (position < segment_end)), 1] = c.y
+            segment_start = segment_end
+        return Point(xy)
+
+    def point(self, position, error=ERROR):
+        """
+        Find a point between 0 and 1 within the Shape, going through the shape with regard to position.
+
+        :param position: value between 0 and 1 within the shape.
+        :param error: Length error permitted.
+        :return: Point at the given location.
+        """
+        segments = self.segments(False)
+        if len(segments) == 0:
+            return None
+        # Shortcuts
+        try:
+            if position <= 0.0:
+                return segments[0].point(position)
+            if position >= 1.0:
+                return segments[-1].point(position)
+        except ValueError:
+            return self._point_numpy(position, error=error)
+        if self._length is None:
+            self._calc_lengths(error=error, segments=segments)
+
+        if self._length == 0:
+            i = int(round(position * (len(segments) - 1)))
+            return segments[i].point(0.0)
+        # Find which segment the point we search for is located on:
+        segment_start = 0
+        segment_pos = 0
+        segment = segments[0]
+        for index, segment in enumerate(segments):
+            segment_end = segment_start + self._lengths[index]
+            if segment_end >= position:
+                # This is the segment! How far in on the segment is the point?
+                segment_pos = (position - segment_start) / (segment_end - segment_start)
+                break
+            segment_start = segment_end
+        return segment.point(segment_pos)
+
+    def length(self, error=ERROR, min_depth=MIN_DEPTH):
+        self._calc_lengths(error, min_depth)
+        return self._length
 
     def segments(self, transformed=True):
         """
@@ -3432,7 +3534,7 @@ class QuadraticBezier(PathSegment):
             return self.end
         raise IndexError
 
-    def point(self, pos):
+    def point(self, position):
         """Calculate the x,y position at a certain position of the path. `pos` maybe either
         a float or a NumPy array."""
 
@@ -3440,10 +3542,10 @@ class QuadraticBezier(PathSegment):
         x1, y1 = self.control
         x2, y2 = self.end
 
-        n_pos = 1 - pos
-        pos_2 = pos ** 2
+        n_pos = 1 - position
+        pos_2 = position ** 2
         n_pos_2 = n_pos ** 2
-        n_pos_pos = n_pos * pos
+        n_pos_pos = n_pos * position
 
         x = n_pos_2 * x0 + 2 * n_pos_pos * x1 + pos_2 * x2
         y = n_pos_2 * y0 + 2 * n_pos_pos * y1 + pos_2 * y2
@@ -3600,7 +3702,7 @@ class CubicBezier(PathSegment):
         self.control2 = self.control1
         self.control1 = c2
 
-    def point(self, pos):
+    def point(self, position):
         """Calculate the x,y position at a certain position of the path. `pos` may be a
         float or a NumPy array."""
 
@@ -3610,11 +3712,11 @@ class CubicBezier(PathSegment):
         x3, y3 = self.end
 
         # compute factors
-        pos_3 = pos ** 3
-        n_pos = 1 - pos
+        pos_3 = position ** 3
+        n_pos = 1 - position
         n_pos_3 = n_pos ** 3
-        pos_2_n_pos = pos * pos * n_pos
-        n_pos_2_pos = n_pos * n_pos * pos
+        pos_2_n_pos = position * position * n_pos
+        n_pos_2_pos = n_pos * n_pos * position
 
         x = n_pos_3 * x0 + 3 * (n_pos_2_pos * x1 + pos_2_n_pos * x2) + pos_3 * x3
         y = n_pos_3 * y0 + 3 * (n_pos_2_pos * y1 + pos_2_n_pos * y2) + pos_3 * y3
@@ -4904,47 +5006,6 @@ class Path(Shape, MutableSequence):
         self.append(segment)
         return self
 
-    def _calc_lengths(self, error=ERROR, min_depth=MIN_DEPTH):
-        if self._length is not None:
-            return
-        lengths = [each.length(error=error, min_depth=min_depth) for each in self._segments]
-        self._length = sum(lengths)
-        if self._length == 0:
-            self._lengths = lengths
-        else:
-            self._lengths = [each / self._length for each in lengths]
-
-    def point(self, position, error=ERROR):
-        if len(self._segments) == 0:
-            return None
-        # Shortcuts
-        if position <= 0.0:
-            return self._segments[0].point(position)
-        if position >= 1.0:
-            return self._segments[-1].point(position)
-
-        self._calc_lengths(error=error)
-
-        if self._length == 0:
-            i = int(round(position * (len(self._segments) - 1)))
-            return self._segments[i].point(0.0)
-        # Find which segment the point we search for is located on:
-        segment_start = 0
-        segment_pos = 0
-        segment = self._segments[0]
-        for index, segment in enumerate(self._segments):
-            segment_end = segment_start + self._lengths[index]
-            if segment_end >= position:
-                # This is the segment! How far in on the segment is the point?
-                segment_pos = (position - segment_start) / (segment_end - segment_start)
-                break
-            segment_start = segment_end
-        return segment.point(segment_pos)
-
-    def length(self, error=ERROR, min_depth=MIN_DEPTH):
-        self._calc_lengths(error, min_depth)
-        return self._length
-
     def append(self, value):
         if isinstance(value, str):
             value = Path(value)
@@ -5680,7 +5741,7 @@ class _RoundShape(Shape):
         py = cy + a * cosT * sinTheta + b * sinT * cosTheta
         return Point(px, py)
 
-    def point(self, position):
+    def point(self, position, error=ERROR):
         """
         find the point that corresponds to given value [0,1].
         Where t=0 is the first point and t=1 is the final point.


### PR DESCRIPTION
* Corrects a crash with str() point in np-point mode.
* Applied the corrections in the master branch for Shape.point() being added there.
* Added _point_numpy (might be inefficient, I just picked up np yesterday).
* Rename QuadraticBezier and CubicBezier `pos` to `position` for consistency sake.

Semi-draft suggestion.

```
>>> from svgelements import *
>>> p = np.linspace(0,1,100)
>>> q = Path("m 4846.67879823,1549.60236153 a 178.903,202.008 180 0,1 176.27867894,168.852051849 c 61.5750144263,3.66977517803 122.980691051,8.96235122858 184.079270214,17.0535403814 c 179.255313836,58.8786355684 297.6283588,263.638314536 314.698319816,436.570894286 c 20.7910506805,207.314074592 -43.896779391,484.937283795 -226.482008619,607.865081451 c -79.4754806573,51.1159380692 -114.798793676,43.9251997216 -196.126727264,44.9333320012 c -39.3684733952,0.489461247795 -52.2930134247,-8.20992297813 -186.390000974,-28.3307275306 c -3.78148286602,225.675187013 -3.90384817798,9.97672019197 -3.45385961147,245.241005667 l -710.362608737,-68.687596865 c 0,0 8.28136853125,-624.518210954 29.5520122891,-923.465746764 c 26.4463017267,-147.778653079 168.952944023,-323.648158205 324.292549727,-343.821382478 c 39.725306434,1.2208900318 79.5346896792,1.99021258982 119.363809266,2.67348470268 a 178.903,202.008 180 0,1 174.551354407,-158.884015646 z m -6.02945206458,45.5274353273 a 65.4392,65.4392 180 0,0 -65.4303112063,65.4305875151 a 65.4392,65.4392 180 0,0 65.4303112063,65.4416003933 a 65.4392,65.4392 180 0,0 65.4417582839,-65.4416003933 a 65.4392,65.4392 -180 0,0 -65.4417582839,-65.4305875151 z")
>>> n = q.point(p)
>>> n
Point([9.88176395e-244 4.89620473e+003 4.94184284e+003 4.98002478e+003
 5.00776518e+003 5.02289509e+003 5.07557519e+003 5.12848895e+003
 5.18127985e+003 5.23239757e+003 5.27948330e+003 5.32305192e+003
 5.36290323e+003 5.39883702e+003 5.43065310e+003 5.45815124e+003
 5.48113125e+003 5.49939292e+003 5.51273605e+003 5.52096042e+003
 5.52474471e+003 5.52528794e+003 5.52250832e+003 5.51631225e+003
 5.50660612e+003 5.49329632e+003 5.47628926e+003 5.45549132e+003
 5.43080889e+003 5.40214838e+003 5.36941616e+003 5.33251864e+003
 5.28976271e+003 5.23656065e+003 5.19087360e+003 5.14335748e+003
 5.09202764e+003 5.06189298e+003 5.02020218e+003 4.94721035e+003
 4.91131467e+003 4.90992502e+003 4.90925089e+003 4.90910431e+003
 4.90663876e+003 4.85377132e+003 4.80090388e+003 4.74803643e+003
 4.69516899e+003 4.64230155e+003 4.58943411e+003 4.53656666e+003
 4.48369922e+003 4.43083178e+003 4.37796434e+003 4.32509689e+003
 4.27222945e+003 4.21936201e+003 4.19895095e+003 4.19913728e+003
 4.19949643e+003 4.20003378e+003 4.20075469e+003 4.20166452e+003
 4.20276864e+003 4.20407241e+003 4.20558120e+003 4.20730037e+003
 4.20923528e+003 4.21139131e+003 4.21377382e+003 4.21638816e+003
 4.21923972e+003 4.22233384e+003 4.22567590e+003 4.23047795e+003
 4.24431854e+003 4.26511779e+003 4.29213262e+003 4.32461996e+003
 4.36183674e+003 4.40303990e+003 4.44748635e+003 4.49443305e+003
 4.54313690e+003 4.59548417e+003 4.64860080e+003 4.68023098e+003
 4.70481557e+003 4.74056151e+003 4.78466094e+003 4.83364984e+003
 4.80363457e+003 4.77603181e+003 4.78872104e+003 4.83378898e+003
 4.88313770e+003 4.90600075e+003 4.88812095e+003 8.89244026e+271],[2.64521692e+185 1.55756159e+003 1.58069308e+003 1.61718822e+003
 1.66419354e+003 1.71803378e+003 1.72201591e+003 1.72657052e+003
 1.73226166e+003 1.74496401e+003 1.76883551e+003 1.79907939e+003
 1.83481546e+003 1.87516351e+003 1.91924337e+003 1.96617482e+003
 2.01507768e+003 2.06507175e+003 2.11527683e+003 2.16481273e+003
 2.21443014e+003 2.26604856e+003 2.31905499e+003 2.37279974e+003
 2.42663312e+003 2.47990544e+003 2.53196701e+003 2.58216815e+003
 2.62985918e+003 2.67439039e+003 2.71511210e+003 2.75137463e+003
 2.78342643e+003 2.81075684e+003 2.82222469e+003 2.82472281e+003
 2.82486097e+003 2.82203195e+003 2.81447098e+003 2.80187946e+003
 2.86951651e+003 2.91039272e+003 2.91780220e+003 2.94608694e+003
 3.04153191e+003 3.03641996e+003 3.03130801e+003 3.02619606e+003
 3.02108411e+003 3.01597216e+003 3.01086021e+003 3.00574827e+003
 3.00063632e+003 2.99552437e+003 2.99041242e+003 2.98530047e+003
 2.98018852e+003 2.97507657e+003 2.97081291e+003 2.95774516e+003
 2.93404337e+003 2.90079021e+003 2.85906832e+003 2.80996036e+003
 2.75454897e+003 2.69391683e+003 2.62914656e+003 2.56132084e+003
 2.49152231e+003 2.42083363e+003 2.35033745e+003 2.28111641e+003
 2.21425319e+003 2.15083042e+003 2.09193076e+003 2.03940288e+003
 1.99132636e+003 1.94295595e+003 1.89561463e+003 1.85062536e+003
 1.80931112e+003 1.77299487e+003 1.74299959e+003 1.72064824e+003
 1.70726380e+003 1.70696780e+003 1.70806983e+003 1.67821276e+003
 1.62886882e+003 1.58916626e+003 1.56222371e+003 1.55015753e+003
 1.60661034e+003 1.65028726e+003 1.70037255e+003 1.72564045e+003
 1.71033473e+003 1.66400043e+003 1.61552481e+003 1.49872792e+248])
```
